### PR TITLE
Leaking pollqueue goroutine

### DIFF
--- a/sqs.go
+++ b/sqs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/TylerBrock/colorjson"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -73,16 +74,17 @@ func (s *sqsClient) deleteQueue(ctx context.Context) error {
 	return err
 }
 
-func (s *sqsClient) pollQueue(ctx context.Context, breaker <-chan struct{}, prettyJSON bool) error {
+func (s *sqsClient) pollQueue(ctx context.Context, signalChan chan os.Signal, prettyJSON bool) {
 	log.Printf("polling queue %s ...", s.queueURL)
 	log.Printf("press ctr+c to stop")
+	defer close(signalChan)
 
 	for {
 		// goroutine
 		select {
-		case <-breaker:
+		case <-signalChan:
 			log.Printf("stopping poller...")
-			return nil
+			return
 
 		default:
 			resp, err := s.client.ReceiveMessageRequest(&sqs.ReceiveMessageInput{
@@ -93,7 +95,8 @@ func (s *sqsClient) pollQueue(ctx context.Context, breaker <-chan struct{}, pret
 			}).Send(ctx)
 			if err != nil {
 				log.Printf("sqs.ReceiveMessage error: %s", err)
-				return err
+				// continue, to handle 'dial tcp' issues
+				continue
 			}
 
 			if len(resp.Messages) == 0 {
@@ -111,7 +114,7 @@ func (s *sqsClient) pollQueue(ctx context.Context, breaker <-chan struct{}, pret
 					var j map[string]interface{}
 					err := json.Unmarshal([]byte(*m.Body), &j)
 					if err != nil {
-						return err
+						return
 					}
 
 					f := colorjson.NewFormatter()

--- a/sqs.go
+++ b/sqs.go
@@ -99,6 +99,7 @@ func (s *sqsClient) pollQueue(ctx context.Context, signalChan chan os.Signal, pr
 				log.Printf("sqs.ReceiveMessage error: %s", err)
 				continue
 			}
+			// handle all other errors
 			if err != nil {
 				log.Printf("sqs.ReceiveMessage error: %s", err)
 				return


### PR DESCRIPTION
https://github.com/spezam/eventbridge-cli/issues/9

```go
signalChan chan os.Signal
```
controls pollQueue goroutine behavior.

```go
defer close(signalChan)
```
make sure the signalChan is closed in case the go routine returns.

Error checking on ReceiveMessageRequest handles two cases:
```go
resp, err := s.client.ReceiveMessageRequest(&sqs.ReceiveMessageInput{})
```
- networking error (continue retrying in order to recover and cleanup temporary resources):
```go
if err != nil && strings.Contains(err.Error(), "dial tcp") {
    log.Printf("sqs.ReceiveMessage error: %s", err)
    continue
}
```

- normal error (trigger return and defer on the signalChan)
```go
if err != nil {
    log.Printf("sqs.ReceiveMessage error: %s", err)
    return
}
```

