### PR TITLE
fix(gomod) Update module name to enable go get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module eventbridge-cli
+module github.com/spezam/eventbridge-cli
 
 go 1.13
 


### PR DESCRIPTION
Currently you get the following error.

```
$ GOBIN=$PWD/bin GO111MODULE=on go install github.com/spezam/eventbridge-cli
go: finding module for package github.com/spezam/eventbridge-cli
go: downloading github.com/spezam/eventbridge-cli v1.2.0
go: found github.com/spezam/eventbridge-cli in github.com/spezam/eventbridge-cli v1.2.0
go: github.com/spezam/eventbridge-cli: github.com/spezam/eventbridge-cli@v1.2.0: parsing go.mod:
	module declares its path as: eventbridge-cli
	        but was required as: github.com/spezam/eventbridge-cli
```

Cheers