### PR TITLE
Minor code cleanup

### DIFF
--- a/eventbridge.go
+++ b/eventbridge.go
@@ -57,7 +57,7 @@ func (e *eventbridgeClient) putTarget(ctx context.Context, sqsArn string) error 
 		Rule:         aws.String(namespace + "-" + runID),
 		EventBusName: aws.String(e.eventBusName),
 		Targets: []eventbridge.Target{
-			eventbridge.Target{
+			{
 				Id:  aws.String(namespace + "-" + runID),
 				Arn: aws.String(sqsArn),
 			},

--- a/sqs.go
+++ b/sqs.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/TylerBrock/colorjson"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -97,6 +98,9 @@ func (s *sqsClient) pollQueue(ctx context.Context, signalChan chan os.Signal, pr
 			// handle recovery from 'dial tcp' errors
 			if err != nil && strings.Contains(err.Error(), "dial tcp") {
 				log.Printf("sqs.ReceiveMessage error: %s", err)
+
+				// backoff
+				time.Sleep(10 * time.Second)
 				continue
 			}
 			// handle all other errors


### PR DESCRIPTION
Changes explained:
- defer function to cleanup temporary resources
- removed unused go routine wrapping signalChan
- added backoff (sleep) when sqs "dial tcp" error is received