### PR TITLE
Eventpattern from SAM template

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ eventbridge-cli -p myawsprofile -j \
 
 # event pattern from SAM template, BetaFunction lambda function
 eventbridge-cli -p myawsprofile -j \
-	-e sam://testdata/template.yaml/BetaFunction \
+   -e sam://testdata/template.yaml/BetaFunction \
    ci -i file://testdata/event_ci_success.json
 
 # listen to events from other sources (lambda, aws cli, sam local, ...)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ EventBus --> EventBrige Rule --> SQS <-- poller
 Features:
 - Listen to Event Bus messages
 - Filter messages by event pattern
-- Read event pattern from cli or file
+- Read event pattern from cli, file or directly from SAM template
 - Authentication via profile or env variables
 - Pretty JSON output
 - CI mode
@@ -58,7 +58,7 @@ GLOBAL OPTIONS:
    --profile value, -p value       AWS profile (default: "default") [$AWS_PROFILE]
    --region value, -r value        AWS region [$AWS_DEFAULT_REGION]
    --eventbusname value, -b value  EventBridge Bus Name (default: "default")
-   --eventpattern value, -e value  EventBridge event pattern. Can be prefixed by 'file://' (default: "{\"source\": [{\"anything-but\": [\"eventbridge-cli\"]}]}")
+   --eventpattern value, -e value  EventBridge event pattern. Can be prefixed by 'file://' or 'sam://' (default: "{\"source\": [{\"anything-but\": [\"eventbridge-cli\"]}]}")
    --prettyjson, -j                Pretty JSON output (default: false)
    --help, -h                      show help (default: false)
    --version, -v                   print the version (default: false)
@@ -83,6 +83,11 @@ eventbridge-cli -p myawsprofile -j \
 eventbridge-cli -p myawsprofile -j \
 	-b fishnchips-eventbus \
 	-e file://testdata/eventpattern.json
+
+# with event pattern from SAM template, function BetaFunction
+eventbridge-cli -p myawsprofile -j \
+	-b fishnchips-eventbus \
+	-e sam://testdata/template.yaml/BetaFunction
 ```
 
 ![screenshot](assets/screenshot.png)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Amazon EventBridge is a serverless event bus that makes it easy to connect applications together using data from your own applications, integrated Software-as-a-Service (SaaS) applications, and AWS services.
 
-Eventbridge-cli is a tool to listen to an EventBus events. Useful for debugging and event pattern testing.
+Eventbridge-cli is a tool to listen to an EventBus events. Useful for debugging, event pattern testing, CI pipelines integration.
 ```
 EventBus --> EventBrige Rule --> SQS <-- poller
 ```
@@ -12,7 +12,7 @@ EventBus --> EventBrige Rule --> SQS <-- poller
 Features:
 - Listen to Event Bus messages
 - Filter messages by event pattern
-- Read event pattern from cli, file or directly from SAM template
+- Read event pattern from cli, file or SAM template
 - Authentication via profile or env variables
 - Pretty JSON output
 - CI mode
@@ -66,25 +66,25 @@ GLOBAL OPTIONS:
 
 ### Usage example:
 ```sh
-# with env variables
+# env variables
 AWS_PROFILE=myawsprofile eventbridge-cli
 AWS_PROFILE=myawsprofile AWS_DEFAULT_REGION=eu-north-1 eventbridge-cli
 
-# with cli flags
+# cli flags
 eventbridge-cli -p myawsprofile
 eventbridge-cli -p myawsprofile -r eu-north-1
 
-# with event pattern
+# event pattern
 eventbridge-cli -p myawsprofile -j \
 	-b fishnchips-eventbus \
 	-e '{"source":["gamma"],"detail":{"channel":["web"]}}'
 
-# with event pattern from file in testdata/eventpattern.json
+# event pattern from file in testdata/eventpattern.json
 eventbridge-cli -p myawsprofile -j \
 	-b fishnchips-eventbus \
 	-e file://testdata/eventpattern.json
 
-# with event pattern from SAM template, function BetaFunction
+# event pattern from SAM template, BetaFunction lambda function
 eventbridge-cli -p myawsprofile -j \
 	-b fishnchips-eventbus \
 	-e sam://testdata/template.yaml/BetaFunction
@@ -95,10 +95,10 @@ eventbridge-cli -p myawsprofile -j \
 ## CI mode
 CI mode can be used to perform integration testing in an automated way.
 
-Given an event pattern (*global* flag -e) and an input event (*ci* flag -i), verifies the message goes through the event bus within timeout (ci flag -t).
+Given an event pattern (*global* flag -e) and an input event (*ci* flag -i), verifies the message goes through the event bus within timeout (*ci* flag -t).
 
 Note: global flags are position sensitive and can't be used under 'ci' command. For example:
-```
+```sh
 eventbridge-cli -j ci -t 20
 ```
 
@@ -123,28 +123,34 @@ OPTIONS:
 ```sh
 # event pattern and input event from cli
 eventbridge-cli -p myawsprofile -j \
-   -e '{"source": ["delta"]}' ci \
-   -i '{"source":"delta", "detail":"{\"channel\":\"web\"}", "detail-type": "poc"}'
+   -e '{"source": ["beta"]}' \
+   ci -i '{"source":"beta", "detail":"{\"channel\":\"web\"}", "detail-type": "poc"}'
 
 # specify timeout
 eventbridge-cli -p myawsprofile -j \
-   -e '{"source": ["delta"]}' ci \
-   -i '{"source":"delta", "detail":"{\"channel\":\"web\"}", "detail-type": "poc"}' \
+   -e '{"source": ["beta"]}' \
+   ci -i '{"source":"beta", "detail":"{\"channel\":\"web\"}", "detail-type": "poc"}' \
    -t 20
 
 # event pattern and input event from file
 eventbridge-cli -p myawsprofile -j \
-   -e file://testdata/eventpattern.json ci \
-   -i file://testdata/event_ci_success.json
+   -e file://testdata/eventpattern.json \
+   ci -i file://testdata/event_ci_success.json
 
 # event pattern and input event from file - failing CI
 eventbridge-cli -p myawsprofile -j \
-   -e file://testdata/eventpattern.json ci \
-   -i file://testdata/event_ci_fail.json
+   -e file://testdata/eventpattern.json \
+   ci -i file://testdata/event_ci_fail.json
 
-# listen to events from other sources (Lambda, aws cli, SAM, ...)
+# event pattern from SAM template, BetaFunction lambda function
 eventbridge-cli -p myawsprofile -j \
-   -e file://testdata/eventpattern.json ci
+	-e sam://testdata/template.yaml/BetaFunction \
+   ci -i file://testdata/event_ci_success.json
+
+# listen to events from other sources (lambda, aws cli, sam local, ...)
+eventbridge-cli -p myawsprofile -j \
+   -e file://testdata/eventpattern.json \
+   ci
 ```
 
 ### Content-based Filtering with Event Patterns reference:

--- a/data_sources.go
+++ b/data_sources.go
@@ -27,7 +27,7 @@ type samTemplate struct {
 	} `yaml:"Resources"`
 }
 
-// file://pattern.json
+// file://eventpattern.json
 func dataFromFile(filepath string) (string, error) {
 	file := strings.Replace(filepath, "file://", "", -1)
 
@@ -58,9 +58,9 @@ func dataFromSAM(sampath string) (string, error) {
 
 	// find EventBridgeRule and marshal to JSON
 	var p []byte
-	for _, k := range b.Resources[function].Properties.Events {
-		if k.Type == "EventBridgeRule" {
-			if p, err = json.Marshal(convertMap(k.Properties.Pattern)); err != nil {
+	for _, e := range b.Resources[function].Properties.Events {
+		if e.Type == "EventBridgeRule" {
+			if p, err = json.Marshal(convertMap(e.Properties.Pattern)); err != nil {
 				return "", err
 			}
 		}
@@ -73,11 +73,11 @@ func dataFromSAM(sampath string) (string, error) {
 func convertMap(i interface{}) interface{} {
 	switch x := i.(type) {
 	case map[interface{}]interface{}:
-		m2 := map[string]interface{}{}
+		m := map[string]interface{}{}
 		for k, v := range x {
-			m2[k.(string)] = convertMap(v)
+			m[k.(string)] = convertMap(v)
 		}
-		return m2
+		return m
 
 	case []interface{}:
 		for i, v := range x {

--- a/data_sources.go
+++ b/data_sources.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type samTemplate struct {
+	Resources map[string]struct {
+		Type       string `yaml:"Type"`
+		Properties struct {
+			FunctionName string `yaml:"FunctionName"`
+			Events       map[string]struct {
+				Type       string `yaml:"Type"`
+				Properties struct {
+					EventBusName string      `yaml:"EventBusName,omitempty"`
+					InputPath    string      `yaml:"InputPath,omitempty"`
+					Pattern      interface{} `yaml:"Pattern,omitempty"`
+				} `yaml:"Properties"`
+			} `yaml:"Events"`
+		} `yaml:"Properties"`
+	} `yaml:"Resources"`
+}
+
+// file://pattern.json
+func dataFromFile(filepath string) (string, error) {
+	file := strings.Replace(filepath, "file://", "", -1)
+
+	e, err := ioutil.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+
+	return string(e), nil
+}
+
+// sam://template.yaml/FunctionName
+func dataFromSAM(sampath string) (string, error) {
+	function := path.Base(sampath)
+	template := strings.Replace(sampath, "sam://", "", -1)
+	template = strings.Replace(template, fmt.Sprintf("/%s", function), "", -1)
+
+	e, err := ioutil.ReadFile(template)
+	if err != nil {
+		return "", err
+	}
+
+	// unmarshal SAM template
+	b := &samTemplate{}
+	if err := yaml.Unmarshal([]byte(e), &b); err != nil {
+		return "", err
+	}
+
+	// find EventBridgeRule and marshal to JSON
+	var p []byte
+	for _, k := range b.Resources[function].Properties.Events {
+		if k.Type == "EventBridgeRule" {
+			if p, err = json.Marshal(convertMap(k.Properties.Pattern)); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	return string(p), nil
+}
+
+// convert map[interface{}]interface{} to map[string]interface{}
+func convertMap(i interface{}) interface{} {
+	switch x := i.(type) {
+	case map[interface{}]interface{}:
+		m2 := map[string]interface{}{}
+		for k, v := range x {
+			m2[k.(string)] = convertMap(v)
+		}
+		return m2
+
+	case []interface{}:
+		for i, v := range x {
+			x[i] = convertMap(v)
+		}
+	}
+
+	return i
+}

--- a/flags.go
+++ b/flags.go
@@ -29,7 +29,7 @@ var flags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "eventpattern",
 		Aliases: []string{"e"},
-		Usage:   "EventBridge event pattern. Can be prefixed by 'file://'",
+		Usage:   "EventBridge event pattern. Can be prefixed by 'file://' or 'sam://'",
 		Value:   fmt.Sprintf(`{"source": [{"anything-but": ["%s"]}]}`, namespace),
 	},
 	&cli.BoolFlag{

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/TylerBrock/colorjson v0.0.0-20180527164720-95ec53f28296
-	github.com/aws/aws-sdk-go-v2 v0.21.0
-	github.com/awslabs/smithy-go v0.0.0-20200423220344-7aaaf91e17c1 // indirect
+	github.com/aws/aws-sdk-go-v2 v0.22.0
+	github.com/awslabs/smithy-go v0.0.0-20200430161030-754ad5df27cc // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.9.0 // indirect
@@ -15,5 +15,6 @@ require (
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/urfave/cli/v2 v2.2.0
-	golang.org/x/sys v0.0.0-20200427175716-29b57079015a // indirect
+	golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -5,12 +5,15 @@ github.com/aws/aws-sdk-go-v2 v0.20.0 h1:/yefUjgMrda9PNFwWctBU63nL10CJMdBwkAmaQ4w
 github.com/aws/aws-sdk-go-v2 v0.20.0/go.mod h1:2LhT7UgHOXK3UXONKI5OMgIyoQL6zTAw/jwIeX6yqzw=
 github.com/aws/aws-sdk-go-v2 v0.21.0 h1:95HzeBHoSMSajvYGiRHUruRC2/sH1YZZTMEv9Q/2T5w=
 github.com/aws/aws-sdk-go-v2 v0.21.0/go.mod h1:gI/sZexbRyMiFze3cbQ/qGJg5yZdacy6WYlpIWNKfHU=
+github.com/aws/aws-sdk-go-v2 v0.22.0 h1:mlixfS5HVzn7Sf3KVhjAIM2H3bB7uoTbLCtKHvteUfE=
+github.com/aws/aws-sdk-go-v2 v0.22.0/go.mod h1:2LhT7UgHOXK3UXONKI5OMgIyoQL6zTAw/jwIeX6yqzw=
 github.com/awslabs/smithy-go v0.0.0-20200421200441-f1e89484c1b9 h1:oNbA/uNHusPiGZiXqC8RSo11xvDBQwe66uimIon1QFk=
 github.com/awslabs/smithy-go v0.0.0-20200421200441-f1e89484c1b9/go.mod h1:L4SfPH3TPbKwyBENwHDh61AAQPvFh5wR00tNeUR7OrU=
 github.com/awslabs/smithy-go v0.0.0-20200422193540-86ef03cc15e0 h1:2yWMiJQd9UezIiBkcUADol/6Y4OWjy/hvuOK1YEVxw0=
 github.com/awslabs/smithy-go v0.0.0-20200422193540-86ef03cc15e0/go.mod h1:L4SfPH3TPbKwyBENwHDh61AAQPvFh5wR00tNeUR7OrU=
 github.com/awslabs/smithy-go v0.0.0-20200423220344-7aaaf91e17c1 h1:nosnvBYNzN3pl5jRT//5qiXsbEUNO2KlVQKAlnd+3iY=
 github.com/awslabs/smithy-go v0.0.0-20200423220344-7aaaf91e17c1/go.mod h1:L4SfPH3TPbKwyBENwHDh61AAQPvFh5wR00tNeUR7OrU=
+github.com/awslabs/smithy-go v0.0.0-20200430161030-754ad5df27cc/go.mod h1:L4SfPH3TPbKwyBENwHDh61AAQPvFh5wR00tNeUR7OrU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -67,6 +70,8 @@ golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslY
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200427175716-29b57079015a h1:08u6b1caTT9MQY4wSbmsd4Ulm6DmgNYnbImBuZjGJow=
 golang.org/x/sys v0.0.0-20200427175716-29b57079015a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 h1:5B6i6EAiSYyejWfvc5Rc9BbI3rzIsrrXfAQBWnYfn+w=
+golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -75,3 +80,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ var (
 func main() {
 	app := &cli.App{
 		Name:    namespace,
-		Version: "1.3.0",
+		Version: "1.3.2",
 		Usage:   "AWS EventBridge cli",
 		Authors: []*cli.Author{
 			{Name: "matteo ridolfi"},

--- a/testdata/event_ci_success.json
+++ b/testdata/event_ci_success.json
@@ -1,5 +1,5 @@
 {
-    "source": "delta",
+    "source": "beta",
     "detail": "{\"channel\": \"web\"}",
     "detail-type": "poc.succeeded"
 }

--- a/testdata/template.yaml
+++ b/testdata/template.yaml
@@ -1,0 +1,27 @@
+Transform: AWS::Serverless-2016-10-31
+Description: EventBridge Beta Integration
+
+Resources:
+  BetaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: eventbridge-beta
+      Description: "EventBridge - Beta (β)"
+      Handler: beta
+      Runtime: go1.x
+      Timeout: 6
+      CodeUri: ./source/
+      Tracing: Active
+      Events:
+        EventBridge:
+          Type: EventBridgeRule
+          Properties:
+            EventBusName: SomeEventBus
+            Pattern:
+              source:
+              - beta
+              detail:
+                channel:
+                - web
+            # also valid
+            # Pattern: { "source": [ "beta" ], "detail": { "channel": [ "web" ] } }


### PR DESCRIPTION
Event pattern can be pulled from a SAM template using the format:
sam://template.yaml/LambdaFunctionName

Valid configurations:
```yaml
      Events:
        EventBridge:
          Type: EventBridgeRule
          Properties:
            EventBusName: SomeEventBus
            Pattern:
              source:
              - beta
              detail:
                channel:
                - web
```
```yaml
      Events:
        EventBridge:
          Type: EventBridgeRule
          Properties:
            Pattern: { "source": [ "beta" ], "detail": { "channel": [ "web" ] } }
```