### PR TITLE
Add default SQS encryption

### DIFF
--- a/sqs.go
+++ b/sqs.go
@@ -60,6 +60,7 @@ func (s *sqsClient) createQueue(ctx context.Context, ruleArn string) error {
 					}
 				}]
 			}`, runID, s.arn, ruleArn),
+			"SqsManagedSseEnabled": "true",
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
I noticed an eventbridge-cli created queue showed up on AWS Security Hub in a test environment because it wasn't encrypted, so I thought I'd raise a PR to add it.

Before...

<img width="1821" alt="Screenshot 2022-01-24 at 14 00 12" src="https://user-images.githubusercontent.com/1029947/150796780-2658158b-1f0d-46e3-b731-b2193f31aef9.png">

After...

<img width="1815" alt="Screenshot 2022-01-24 at 13 59 37" src="https://user-images.githubusercontent.com/1029947/150796803-8448885b-98a3-4984-90a8-93a0362a5306.png">
