### PR TITLE
bump github/codeql-action to v4.37.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,14 +25,14 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:go"


### PR DESCRIPTION
Manual replacement for dependabot PRs #314/#315/#316, which each bumped only one of the three matching codeql-action references (init/autobuild/analyze) individually. CodeQL rejects a mismatched init-vs-analyze version ("Loaded a configuration file for version '4.37.0', but running version '4.36.2'"), so each of those PRs failed the `analyze` check on its own. This PR bumps all three lines together to v4.37.0 (SHA 99df26d4f13ea111d4ec1a7dddef6063f76b97e9).

Closes #314, closes #315, closes #316.